### PR TITLE
Make the README match the role, and make the role work

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,54 +16,74 @@ Red Hat Enterprise Linux 7 or equivalent
 
 Valid Red Hat Subscriptions
 
-Python pip package `pyvmomi`
+Python package `pyvmomi`
 
 Role Variables
 --------------
 
 Currently the following variables are supported:
 
-### General
+### Required
 
+* `vmware_provision_hostname` - The hostname or IP address of the vSphere vCenter or ESXi server. **REQUIRED**
+* `vmware_provision_username` - The username of the vSphere vCenter or ESXi server. **REQUIRED**
+* `vmware_provision_password` - The password of the vSphere vCenter or ESXi server. **REQUIRED**
+
+### Optional
+
+* `vmware_provision_port` - The port of the vSphere vCenter or ESXi server.
+* `vmware_provision_validate_certs` - Whether or not to allow connecting to the vSphere vCenter
+* `vmware_provision_custom_vms` - A list of custom VM configurations to deploy
+to a vSphere vCenter or ESXi server. Each list item represents a VM to be
+provisioned. Parameters of each list item should have key/value pairs that match
+the arguments to the
+[vmware_guest](https://docs.ansible.com/ansible/latest/modules/vmware_guest_module.html#vmware-guest-module)
+module for Ansible.
+* `vmware_provision_ovfs` - A list of configurations using an OVA file to
+deploy to a vSphere vCenter or ESXi server. Each list item represents a VM to
+be provisioned. Parameters of each list item should have key/value pairs that
+match the arguments to the
+[vmware_deploy_ovf](https://docs.ansible.com/ansible/latest/modules/vmware_deploy_ovf_module.html)
+module for Ansible.
+  or ESXi server when its TLS/SSL certificates are invalid.
 * `vmware_provision_become` - Default: true. If this role needs administrator
   privileges, then use the Ansible become functionality (based off sudo).
 * `vmware_provision_become_user` - Default: root. If the role uses the become
   functionality for privilege escalation, then this is the name of the target
   user to change to.
-* `vmware_provision_hostname` - The hostname or IP address of the vSphere vCenter or ESXi server. **REQUIRED**
-* `vmware_provision_username` - The username of the vSphere vCenter or ESXi server. **REQUIRED**
-* `vmware_provision_password` - The password of the vSphere vCenter or ESXi server. **REQUIRED**
-* `vmware_provision_custom_vms` - A list of custom VM configurations to deploy
-to a vSphere vCenter or ESXi server. Each list item represents a VM to be
-provisioned. Parameters of each list item should have key/value pairs that match
-the arguments to the [vmware_guest](https://docs.ansible.com/ansible/latest/modules/vmware_guest_module.html#vmware-guest-module)
-module for Ansible.
-* `vmware_provision_ovfs` - A list of configurations using an OVA file to
-deploy to a vSphere vCenter or ESXi server. Each list item represents a VM to
-be provisioned. Parameters of each list item should have key/value pairs that
-match the arguments to the [vmware_deploy_ovf](https://docs.ansible.com/ansible/latest/modules/vmware_deploy_ovf_module.html)
-module for Ansible. **Note that the `ovf` parameter only accepts `.ova` files.**
-**You can use VMware's [ovftool](https://code.vmware.com/web/tool/4.3.0/ovf) to convert an ovf template with its supporting files to an ova template**
 
 Dependencies
 ------------
 
-Python pip package `pyvmomi`
+Python package `pyvmomi`
 
 Example Playbook
 ----------------
 
 This example shows a playbook used to provision VMs with custom configurations
+
+Note that these examples are explicitly targeting `localhost` as the playbook host
+assuming that `pyvmomi` was previously installed on the ansible control system.
+
+To run on another host, ensure that the `pyvmomi` package is installed and available
+in the environment in which this role will run (e.g. install it in a prior play, or
+in this play's `pre_tasks`).
+
 ```yaml
 - hosts: localhost
   roles:
     - role: oasis_roles.vmware_provision
   vars:
+    # required
     vmware_provision_hostname: "vCenter.hostname.com"
     vmware_provision_username: "username"
-    vmware_provision_username: "password"
+    vmware_provision_password: "password"
 
-    vmware_provisioned_vms:
+    # optional
+    vmware_provision_port: 443
+    vmware_provision_validate_certs: true
+
+    vmware_provisioned_custom_vms:
       - name: custom_VM-1
         validate_certs: false
         folder: my_vm_folder
@@ -102,6 +122,11 @@ This example shows a playbook used to provision VMs with custom configurations
 ```
 
 This example shows a playbook used to provision VMs using OVA templates located on the host machine
+
+**Note that the `ovf` parameter only accepts `.ova` files.
+You can use VMware's [ovftool](https://code.vmware.com/web/tool/4.3.0/ovf)
+to convert an ovf template with its supporting files to an ova template**
+
 ```yaml
 - hosts: localhost
   roles:
@@ -111,7 +136,7 @@ This example shows a playbook used to provision VMs using OVA templates located 
     vmware_provision_username: "username"
     vmware_provision_username: "password"
 
-    vmware_provision_OVFs:
+    vmware_provision_ovfs:
       - name: ova_VM-1
         ovf: "path/to/local/template.ova"
         validate_certs: false
@@ -126,8 +151,6 @@ This example shows a playbook used to provision VMs using OVA templates located 
         ovf: "path/to/another/local/template.ova"
         wait_for_ip_address: true
 ```
-
-**Note that this role must be run on the localhost to execute properly**
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,16 @@
 vmware_provision_become: true
 vmware_provision_become_user: root
 
-# Credentials to access VMware server
-vmware_provision_hostname: "hostname"
-vmware_provision_username: "username"
-vmware_provision_password: "password"
+# Credentials to access VMware server are required,
+# do not default them
+# vmware_provision_hostname: null
+# vmware_provision_username: null
+# vmware_provision_password: null
+
+# default these to omit here, to allow the module
+# defaults to be used if not specified by the user
+vmware_provision_port: "{{ omit }}"
+vmware_provision_validate_certs: "{{ omit }}"
 
 # Config vars to provision a VM using custom user inputs
 vmware_provision_custom_vms: []

--- a/tasks/deploy_custom.yml
+++ b/tasks/deploy_custom.yml
@@ -5,6 +5,9 @@
     hostname: "{{ vmware_provision_hostname }}"
     username: "{{ vmware_provision_username }}"
     password: "{{ vmware_provision_password }}"
+    port: "{{ item['port'] | default(vmware_provision_port) }}"
+    validate_certs: |-
+      {{ item['validate_certs'] | default(vmware_provision_validate_certs) }}
     annotation: "{{ item['annotation'] | default(omit) }}"
     cdrom: "{{ item['cdrom'] | default(omit) }}"
     cluster: "{{ item['cluster'] | default(omit) }}"
@@ -24,20 +27,17 @@
     linked_clone: "{{ item['linked_clone'] | default(omit) }}"
     name_match: "{{ item['name_match'] | default(omit) }}"
     networks: "{{ item['networks'] | default(omit) }}"
-    port: "{{ item['port'] | default(omit) }}"
     resource_pool: "{{ item['resource_pool'] | default(omit) }}"
     snapshot_src: "{{ item['snapshot_src'] | default(omit) }}"
     state_change_timeout: "{{ item['state_change_timeout'] | default(omit) }}"
     template: "{{ item['template'] | default(omit) }}"
     use_instance_uuid: "{{ item['use_instance_uuid'] | default(omit) }}"
     uuid: "{{ item['uuid'] | default(omit) }}"
-    validate_certs: "{{ item['validate_certs'] | default(omit) }}"
     vapp_properties: "{{ item['vapp_properties'] | default(omit) }}"
     wait_for_customization: "{{ item['wait_for_customization']|default(omit) }}"
     wait_for_ip_address: "{{ item['wait_for_ip_address'] | default(omit) }}"
-  delegate_to: localhost
   register: vm_instance
 
 - name: Append instance info to variable
   set_fact:
-    vmware_provisioned_vms: "{{ provisioned_vms + [vm_instance] }}"
+    vmware_provisioned_vms: "{{ vmware_provisioned_vms + [vm_instance] }}"

--- a/tasks/deploy_ovf.yml
+++ b/tasks/deploy_ovf.yml
@@ -5,6 +5,9 @@
     hostname: "{{ vmware_provision_hostname }}"
     username: "{{ vmware_provision_username }}"
     password: "{{ vmware_provision_password }}"
+    port: "{{ item['port'] | default(vmware_provision_port) }}"
+    validate_certs: |-
+      {{ item['validate_certs'] | default(vmware_provision_validate_certs) }}
     allow_duplicates: "{{ item['allow_duplicates'] | default(omit) }}"
     cluster: "{{ item['cluster'] | default(omit) }}"
     datacenter: "{{ item['datacenter'] | default(omit) }}"
@@ -15,16 +18,13 @@
     folder: "{{ item['folder'] | default(omit) }}"
     inject_ovf_env: "{{ item['inject_ovf_env'] | default(omit) }}"
     networks: "{{ item['networks'] | default(omit) }}"
-    port: "{{ item['port'] | default(omit) }}"
     power_on: "{{ item['power_on'] | default(omit) }}"
     properties: "{{ item['properties'] | default(omit) }}"
     resource_pool: "{{ item['resource_pool'] | default(omit) }}"
-    validate_certs: "{{ item['validate_certs'] | default(omit) }}"
     wait: "{{ item['wait'] | default(omit) }}"
     wait_for_ip_address: "{{ item['wait_for_ip_address'] | default(omit) }}"
-  delegate_to: localhost
   register: vm_instance
 
 - name: Append instance info to variable
   set_fact:
-    vmware_provisioned_vms: "{{ provisioned_vms + [vm_instance] }}"
+    vmware_provisioned_vms: "{{ vmware_provisioned_vms + [vm_instance] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,3 @@
-# role tasks
 - name: Setup var to store instance info
   set_fact:
     vmware_provisioned_vms: []


### PR DESCRIPTION
Several things fixed in here, I was locally developing this role
alongside another one doing some vmware deployments that required some
tweaks to this role. While I was in there, I noticed that all the
playbook examples reflected an older version of this role.

Here are the changes:
- Update README examples to reflect actual usage
- No longer force delegation to localhost, as it's reasonable to need to
  manage vmware from a bastion host, not from the ansible control
  machine directly
- Fix "output" fact (tasks were using incorrect fact var)
- Promote "port" and "verify_certs" to role-level vars, as these are
  common to all vmware modules, and both vmware modules used by this role
- Do not set defaults for required values (fail fast)
- Python packages are not python pip packages